### PR TITLE
Avoid functions that might not be defined on SYCL device

### DIFF
--- a/tensorflow/core/lib/random/random_distributions.h
+++ b/tensorflow/core/lib/random/random_distributions.h
@@ -27,9 +27,6 @@ limitations under the License.
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/lib/random/philox_random.h"
 
-#if defined(TENSORFLOW_USE_SYCL)
-#include <CL/sycl.hpp>
-#endif
 
 namespace tensorflow {
 namespace random {
@@ -377,11 +374,7 @@ class TruncatedNormalDistribution<SingleSampleGenerator, Eigen::half> {
       BoxMullerFloat(x0, x1, &f[0], &f[1]);
 
       for (int i = 0; i < 2; ++i) {
-#if defined(TENSORFLOW_USE_SYCL)
-        if (cl::sycl::fabs(f[i]) < kTruncateValue) {
-#else
-        if (fabs(f[i]) < kTruncateValue) {
-#endif
+        if (Eigen::numext::abs(f[i]) < kTruncateValue) {
           results[index++] = Eigen::half(f[i]);
           if (index >= kResultElementCount) {
             return results;
@@ -424,11 +417,7 @@ class TruncatedNormalDistribution<SingleSampleGenerator, float> {
       BoxMullerFloat(x0, x1, &f[0], &f[1]);
 
       for (int i = 0; i < 2; ++i) {
-#if defined(TENSORFLOW_USE_SYCL)
-        if (cl::sycl::fabs(f[i]) < kTruncateValue) {
-#else
-        if (fabs(f[i]) < kTruncateValue) {
-#endif
+        if (Eigen::numext::abs(f[i]) < kTruncateValue) {
           results[index++] = f[i];
           if (index >= kResultElementCount) {
             return results;
@@ -470,11 +459,7 @@ class TruncatedNormalDistribution<SingleSampleGenerator, double> {
       BoxMullerDouble(x0, x1, x2, x3, &d[0], &d[1]);
 
       for (int i = 0; i < 2; ++i) {
-#if defined(TENSORFLOW_USE_SYCL)
-        if (cl::sycl::fabs(d[i]) < kTruncateValue) {
-#else
-        if (fabs(d[i]) < kTruncateValue) {
-#endif
+        if (Eigen::numext::abs(d[i]) < kTruncateValue) {
           results[index++] = d[i];
           if (index >= kResultElementCount) {
             return results;
@@ -499,21 +484,12 @@ void BoxMullerFloat(uint32 x0, uint32 x1, float* f0, float* f1) {
     u1 = epsilon;
   }
   const float v1 = 2.0f * M_PI * Uint32ToFloat(x1);
-
-#if defined(TENSORFLOW_USE_SYCL)
-  const float u2 = cl::sycl::sqrt(-2.0f * cl::sycl::log(u1));
+  const float u2 = Eigen::numext::sqrt(-2.0f * Eigen::numext::log(u1));
+#if defined(TENSORFLOW_USE_SYCL) || !defined(__linux__)
+  *f0 = Eigen::numext::sin(v1);
+  *f1 = Eigen::numext::cos(v1);
 #else
-  const float u2 = sqrt(-2.0f * log(u1));
-#endif
-
-#if defined(TENSORFLOW_USE_SYCL)
-  *f0 = cl::sycl::sin(v1);
-  *f1 = cl::sycl::cos(v1);
-#elif defined(__linux__)
   sincosf(v1, f0, f1);
-#else
-  *f0 = sinf(v1);
-  *f1 = cosf(v1);
 #endif
   *f0 *= u2;
   *f1 *= u2;
@@ -534,22 +510,12 @@ void BoxMullerDouble(uint32 x0, uint32 x1, uint32 x2, uint32 x3, double* d0,
     u1 = epsilon;
   }
   const double v1 = 2 * M_PI * Uint64ToDouble(x2, x3);
-
-
-#if defined(TENSORFLOW_USE_SYCL)
-  const double u2 = cl::sycl::sqrt(-2.0 * cl::sycl::log(u1));
+  const double u2 = Eigen::numext::sqrt(-2.0 * Eigen::numext::log(u1));
+#if defined(TENSORFLOW_USE_SYCL) || !defined(__linux__)
+  *d0 = Eigen::numext::sin(v1);
+  *d1 = Eigen::numext::cos(v1);
 #else
-  const double u2 = sqrt(-2.0 * log(u1));
-#endif
-
-#if defined(TENSORFLOW_USE_SYCL)
-  *d0 = cl::sycl::sin(v1);
-  *d1 = cl::sycl::cos(v1);
-#elif defined(__linux__)
   sincos(v1, d0, d1);
-#else
-  *d0 = sin(v1);
-  *d1 = cos(v1);
 #endif
   *d0 *= u2;
   *d1 *= u2;


### PR DESCRIPTION
This fixes build warnings (*see example below) introduced in my previous random ops merge request.
The referencing of undefined math functions is suspected to cause test failures on AMD GPUs.

For a full list [see here](http://ci.tensorflow.org/job/tensorflow-opencl/322/console)
```
17:20:11 INFO: From Compiling tensorflow/core/kernels/random_op.cc:
17:20:11 warning: [Computecpp:CC0034]: Function sqrt is undefined but referenced on the device and the associated kernels may fail to build or execute at run time [-Wsycl-undef-func]
17:20:11 warning: [Computecpp:CC0034]: Function log is undefined but referenced on the device and the associated kernels may fail to build or execute at run time [-Wsycl-undef-func]
...
```